### PR TITLE
Revert "Configure EF Core to query as no tracking by default"

### DIFF
--- a/src/StudyPomo.Library/Data/GeneralRepository.cs
+++ b/src/StudyPomo.Library/Data/GeneralRepository.cs
@@ -38,7 +38,7 @@ public class GeneralRepository<T> : IRepository<T> where T : class
             query = query.Include(includeProperty);
         }
 
-        return await query.ToListAsync();
+        return await query.AsNoTracking().ToListAsync();
     }
 
     public async Task<IEnumerable<T>> GetAllAsync(Expression<Func<T, bool>> filter, params Expression<Func<T, object>>[] includeProperties)
@@ -52,7 +52,7 @@ public class GeneralRepository<T> : IRepository<T> where T : class
             query = query.Include(includeProperty);
         }
 
-        return await query.ToListAsync();
+        return await query.AsNoTracking().ToListAsync();
     }
 
     public async Task<T?> GetAsync(Expression<Func<T, bool>> filter, params Expression<Func<T, object>>[] includeProperties)
@@ -66,7 +66,7 @@ public class GeneralRepository<T> : IRepository<T> where T : class
             query = query.Include(includeProperty);
         }
 
-        return await query.FirstOrDefaultAsync();
+        return await query.AsNoTracking().FirstOrDefaultAsync();
     }
 
     public void Remove(T model)

--- a/src/StudyPomo.UI/Program.cs
+++ b/src/StudyPomo.UI/Program.cs
@@ -66,7 +66,6 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 {
     options.UseMySql(builder.Configuration.GetConnectionString("StudyPomo"), new MySqlServerVersion(new Version(8, 0, 33)));
     options.AddInterceptors(new SlowQueryDetectionHelper());
-    options.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
 });
 
 builder.Services.AddIdentity<ApplicationUser, IdentityRole<int>>().AddEntityFrameworkStores<ApplicationDbContext>().AddDefaultTokenProviders();


### PR DESCRIPTION
Reverts kj-49/StudyPomo#244

We don't want to remove tracking from all queries, only read-only queries for large result sets.