### PR TITLE
Fix streak calculator bug & add new test for scenario

### DIFF
--- a/src/StudyPomo.Library/Services/StatisticService.cs
+++ b/src/StudyPomo.Library/Services/StatisticService.cs
@@ -63,7 +63,12 @@ public class StatisticService : IStatisticService
         if (previousDate.Date == DateTime.Today || previousDate.Date == DateTime.Now.AddDays(-1).Date)
         {
             streak++;
+        } else
+        {
+            return 0;
         }
+
+        // If here we have completed a pomodoro today or yesterday
 
         IEnumerable<DateTime> remainingDates = daysWithPomodoros.Skip(1);
 

--- a/tests/StudyPomo.Library.Tests/Services/StatisticServiceTests.cs
+++ b/tests/StudyPomo.Library.Tests/Services/StatisticServiceTests.cs
@@ -119,4 +119,22 @@ public class StatisticServiceTests
         // Act & Assert
         Assert.Throws<ArgumentException>(() => _statisticService.GetCurrentStreak(studySessions));
     }
+
+    [Fact]
+    public void GetCurrentStreak_ShouldReturnZero_WhenConsecutiveButNotRecent()
+    {
+        // Arrange
+        var studySessions = new List<StudySession>
+            {
+                new StudySession { UserId = 2, DateStarted = DateTime.Now.AddDays(-5), TotalPomodoros = 1 },
+                new StudySession { UserId = 2, DateStarted = DateTime.Now.AddDays(-6), TotalPomodoros = 1 },
+                new StudySession { UserId = 2, DateStarted = DateTime.Now.AddDays(-7), TotalPomodoros = 1 },
+            };
+
+        // Act
+        var result = _statisticService.GetCurrentStreak(studySessions);
+
+        // Assert
+        Assert.Equal(0, result);
+    }
 }


### PR DESCRIPTION
The streak calculator would count consecutive days of pomodoros even if that streak didn't continue to today or yesterday.

Closes #256